### PR TITLE
Removing ambiguity if both py2 and py3 installed on same system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a small utility script written to automate the process and notify you wh
 ## How to execute the script
 This script uses python 3.x.
 1) Clone the repo 
-2) Run `pip install -r requirements`
+2) Run `pip3 install -r requirements`
 3) Run the script with `python3 BB_slot.py`
 
 


### PR DESCRIPTION
For systems where both `python2.x` and `python3.x` are installed, `pip` generally installs modules for `python2.x` and `pip3` for `python3.x`. Hence the commit to remove ambiguity. 

Tested on Ubuntu 18.04 image inside Docker.